### PR TITLE
Package.json: Fix name and build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "Shift",
+  "name": "shift",
   "version": "0.1.0",
   "description": "A framework for displaying data, written using ReactJS",
   "author": {
@@ -7,7 +7,7 @@
     "email": "kaare@kaareskovgaard.net"
   },
   "scripts": {
-    "build": "gulp"
+    "build": "gulp build"
   },
   "devDependencies": {
     "gulp": "=3.9.1",


### PR DESCRIPTION
The name has to be lower case (or so VS Code tells me).
And the gulp default is to both build and watch.